### PR TITLE
Update README with usage example and license note

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,26 @@ grad = mr.numerical_grad(x, f)
 print(grad)
 ```
 
+You can also work with spatial transformations using the `SE3` class. The
+following snippet creates a 90 degree rotation around the Z axis with a
+translation, applies the transformation to a point and then inverts it:
+
+```python
+import numpy as np
+import mathrobo as mr
+
+# Rotation of 90 deg about Z and translation of 1 m along X
+rot = mr.SO3.exp(np.array([0.0, 0.0, 1.0]), np.pi / 2)
+T = mr.SE3(rot, np.array([1.0, 0.0, 0.0]))
+
+point = np.array([0.0, 1.0, 0.0])
+transformed = T @ point
+recovered = T.inv() @ transformed
+
+print(transformed)
+print(recovered)
+```
+
 ## Running Tests
 
 To ensure Mathrobo is working correctly, run the tests using:

--- a/README.md
+++ b/README.md
@@ -30,18 +30,6 @@ Refer to the examples in the `examples` folder, where you can find Jupyter noteb
 
 ## Usage
 
-Here is a quick example that computes the numerical gradient of a simple function:
-
-```python
-import numpy as np
-import mathrobo as mr
-
-f = lambda x: np.sum(x**2)
-x = np.array([1.0, 2.0, -3.0])
-grad = mr.numerical_grad(x, f)
-print(grad)
-```
-
 You can also work with spatial transformations using the `SE3` class. The
 following snippet creates a 90 degree rotation around the Z axis with a
 translation, applies the transformation to a point and then inverts it:
@@ -60,6 +48,18 @@ recovered = T.inv() @ transformed
 
 print(transformed)
 print(recovered)
+```
+
+Here is a quick example that computes the numerical gradient of a simple function:
+
+```python
+import numpy as np
+import mathrobo as mr
+
+f = lambda x: np.sum(x**2)
+x = np.array([1.0, 2.0, -3.0])
+grad = mr.numerical_grad(x, f)
+print(grad)
 ```
 
 ## Running Tests

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ pip install .
 ## Examples
 Refer to the examples in the `examples` folder, where you can find Jupyter notebooks and scripts demonstrating various use cases of the library.
 
+## Usage
+
+Here is a quick example that computes the numerical gradient of a simple function:
+
+```python
+import numpy as np
+import mathrobo as mr
+
+f = lambda x: np.sum(x**2)
+x = np.array([1.0, 2.0, -3.0])
+grad = mr.numerical_grad(x, f)
+print(grad)
+```
+
 ## Running Tests
 
 To ensure Mathrobo is working correctly, run the tests using:
@@ -39,3 +53,7 @@ pytest
 
 ## Contributing
 Contributions are welcome! Feel free to report issues, suggest features, or submit pull requests.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -62,6 +62,34 @@ grad = mr.numerical_grad(x, f)
 print(grad)
 ```
 
+You can also perform numerical integration using the Gaussian quadrature helper
+`gq_integrate`:
+
+```python
+import numpy as np
+import mathrobo as mr
+
+f = lambda s: np.array([np.sin(s)])
+val = mr.gq_integrate(f, 0.0, np.pi, digit=5)
+print(val)  # ~ 2.0
+```
+
+For spline trajectories, SciPy's `BSpline` can be used to create and evaluate a
+curve:
+
+```python
+import numpy as np
+from scipy.interpolate import make_interp_spline
+
+t = np.array([0, 1, 2, 3])
+points = np.array([0.0, 1.0, 0.0, 1.0])
+spl = make_interp_spline(t, points, k=3)
+
+ts = np.linspace(0, 3, 20)
+ys = spl(ts)
+print(ys)
+```
+
 ## Running Tests
 
 To ensure Mathrobo is working correctly, run the tests using:


### PR DESCRIPTION
## Summary
- document a simple numerical gradient example in README
- add license section referencing MIT license

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685d2e7fc2188321815130f9e03f94ec